### PR TITLE
Fix error from stat on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PyPi Simple Search
+# PyPi Simple Search (fork)
 
-A stop-gap replacement for `pip search`
+A stop-gap replacement for `pip search`. This fork fixes compatibility for Linux systems, particularly the `stat` command.
 
 ## What?
 

--- a/bin/pypi-simple-search
+++ b/bin/pypi-simple-search
@@ -52,7 +52,7 @@ elif [ ! -f "$PSS_CACHE" ]; then
     curl_pypi
 fi
 
-elapsed_time=$(( $(date +%s) - $(stat -f%c ~/.local/share/pypi-simple-search/simple.txt) ))
+elapsed_time=$(( $(date +%s) - $(stat -f -c %c ~/.local/share/pypi-simple-search/simple.txt) ))
 if [ $elapsed_time -gt 604800 ]; then
     # Update automatically if the cache is over 1 week old
     echo "It's been over a week since the package cache was updated"


### PR DESCRIPTION
The GNU version of stat requires `-c` before any custom flag.